### PR TITLE
added a fix to limit pagesize to 1

### DIFF
--- a/pkg/connector/client/path.go
+++ b/pkg/connector/client/path.go
@@ -60,6 +60,9 @@ func withLimitAndOffset(pageToken string, pageSize int) Option {
 func withPaginationCursor(pageSize int,
 	paginationCursor string,
 ) Option {
+	if pageSize < 1 {
+		pageSize = 1
+	}
 	parameters := map[string]interface{}{
 		"limit": pageSize,
 	}

--- a/pkg/connector/client/path.go
+++ b/pkg/connector/client/path.go
@@ -17,6 +17,8 @@ const (
 	SpacesListUrlPath             = "/wiki/api/v2/spaces"
 	spacesGetUrlPath              = "/wiki/api/v2/spaces/%s"
 	SpacePermissionsListUrlPath   = "/wiki/api/v2/spaces/%s/permissions"
+
+	defaultSize = 100
 )
 
 type Option = func(*url.URL) (*url.URL, error)
@@ -60,8 +62,10 @@ func withLimitAndOffset(pageToken string, pageSize int) Option {
 func withPaginationCursor(pageSize int,
 	paginationCursor string,
 ) Option {
+	// Confluence has limit parameter value Minimum 1
+	// Setting the page size to the defaultSize to reduce the number of calls
 	if pageSize < 1 {
-		pageSize = 1
+		pageSize = defaultSize
 	}
 	parameters := map[string]interface{}{
 		"limit": pageSize,


### PR DESCRIPTION
Error when syncing Confluence - 
```
Failed to sync connector, last step error
{ "error": "error: listing grants for resource space/491524 failed: confluence-connector: request error. Status: 400, Url: https://hvadapalli.atlassian.net/wiki/api/v2/spaces/491524/permissions?limit=0, Body: {\"errors\":[{\"status\":400,\"code\":\"INVALID_REQUEST_PARAMETER\",\"title\":\"Provided size {0} for 'limit' is smaller than the min allowed: 1\",\"detail\":null}]}" }
```

From confluence docs, [limit](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-space-permissions/#api-spaces-id-permissions-get:~:text=string-,limit,-integer) parameter should be at least 1. The current implementation is setting the limit to pageSize and if that is 0 we are getting this error

Tested the fix locally and it worked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced validation for the `pageSize` parameter to ensure it is always set to a minimum of 100, enhancing the reliability of pagination functionality.

- **Bug Fixes**
	- Adjusted control flow to prevent potential errors related to pagination limits, ensuring a smoother user experience when navigating through data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->