### PR TITLE
Group Grant Expansion

### DIFF
--- a/pkg/connector/client/confluence.go
+++ b/pkg/connector/client/confluence.go
@@ -285,7 +285,7 @@ func (c *ConfluenceClient) ConfluenceSpaceOperations(
 	error,
 ) {
 	logger := ctxzap.Extract(ctx)
-	logger.Debug("fetching space", zap.String("spaceId", spaceId))
+	logger.Debug("fetching operations for space", zap.String("spaceId", spaceId))
 
 	spaceUrl, err := c.parse(
 		fmt.Sprintf(spacesGetUrlPath, spaceId),


### PR DESCRIPTION
- Show all entitlements for spaces. The Confluence API doesn't return all operations that can be done to a space.
- Expand group grants on spaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a hard-coded list of operations for space permissions, enhancing entitlement generation.
	- Updated grant creation process to utilize new SDK capabilities for improved flexibility.

- **Bug Fixes**
	- Clarified logging messages for better context in operations.

- **Refactor**
	- Streamlined methods for handling permissions and grants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->