### PR TITLE
Skip emitting grants for unknown permissions on spaces.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,9 +70,7 @@ linters:
     - bodyclose # checks whether HTTP response body is closed successfully
     - durationcheck # check for two durations multiplied together
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - execinquery # execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds
     - exhaustive # check exhaustiveness of enum switch statements
-    - exportloopref # checks for pointers to enclosing loop variables
     - forbidigo # Forbids identifiers
     - gochecknoinits # Checks that no init functions are present in Go code
     - goconst # Finds repeated strings that could be replaced by a constant

--- a/cmd/baton-confluence/config.go
+++ b/cmd/baton-confluence/config.go
@@ -20,6 +20,11 @@ var (
 		field.WithDescription("The username for your Confluence account"),
 		field.WithRequired(true),
 	)
+	skipPersonalSpaces = field.BoolField(
+		"skip-personal-spaces",
+		field.WithDescription("Skip syncing personal spaces and their permissions"),
+		field.WithRequired(false),
+	)
 )
 
 var configuration = field.NewConfiguration(
@@ -27,5 +32,6 @@ var configuration = field.NewConfiguration(
 		apiKeyField,
 		domainUrl,
 		usernameField,
+		skipPersonalSpaces,
 	},
 )

--- a/cmd/baton-confluence/main.go
+++ b/cmd/baton-confluence/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/conductorone/baton-confluence/pkg/connector"
 	"github.com/conductorone/baton-sdk/pkg/config"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/field"
@@ -13,6 +12,8 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
+
+	"github.com/conductorone/baton-confluence/pkg/connector"
 )
 
 var version = "dev"
@@ -53,6 +54,7 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 		v.GetString(apiKeyField.FieldName),
 		v.GetString(domainUrl.FieldName),
 		v.GetString(usernameField.FieldName),
+		v.GetBool(skipPersonalSpaces.FieldName),
 	)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,12 @@ go 1.21
 
 require (
 	github.com/conductorone/baton-sdk v0.2.12
+	github.com/deckarep/golang-set/v2 v2.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.27.0
+	google.golang.org/grpc v1.65.0
 )
 
 require (
@@ -34,7 +36,6 @@ require (
 	github.com/aws/smithy-go v1.20.2 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/doug-martin/goqu/v9 v9.19.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.0.4 // indirect
@@ -84,7 +85,6 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240528184218-531527333157 // indirect
-	google.golang.org/grpc v1.65.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -64,10 +64,11 @@ func New(
 		return nil, err
 	}
 	rv := &Confluence{
-		domain:   domainUrl,
-		apiKey:   apiKey,
-		userName: username,
-		client:   client,
+		domain:             domainUrl,
+		apiKey:             apiKey,
+		userName:           username,
+		client:             client,
+		skipPersonalSpaces: skipPersonalSpaces,
 	}
 	return rv, nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/conductorone/baton-confluence/pkg/connector/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
+
+	"github.com/conductorone/baton-confluence/pkg/connector/client"
 )
 
 const (
@@ -44,10 +45,11 @@ type Config struct {
 }
 
 type Confluence struct {
-	client   *client.ConfluenceClient
-	domain   string
-	apiKey   string
-	userName string
+	client             *client.ConfluenceClient
+	domain             string
+	apiKey             string
+	userName           string
+	skipPersonalSpaces bool
 }
 
 func New(
@@ -55,6 +57,7 @@ func New(
 	apiKey string,
 	domainUrl string,
 	username string,
+	skipPersonalSpaces bool,
 ) (*Confluence, error) {
 	client, err := client.NewConfluenceClient(ctx, username, apiKey, domainUrl)
 	if err != nil {
@@ -99,6 +102,6 @@ func (c *Confluence) ResourceSyncers(ctx context.Context) []connectorbuilder.Res
 	return []connectorbuilder.ResourceSyncer{
 		groupBuilder(c.client),
 		userBuilder(c.client),
-		newSpaceBuilder(c.client),
+		newSpaceBuilder(c.client, c.skipPersonalSpaces),
 	}
 }

--- a/pkg/connector/spaces.go
+++ b/pkg/connector/spaces.go
@@ -93,17 +93,8 @@ var allVerbs = []string{
 	"update",
 }
 
-var nounSet = mapset.NewSet[string]()
-var verbSet = mapset.NewSet[string]()
-
-func init() {
-	for _, noun := range allNouns {
-		nounSet.Add(noun)
-	}
-	for _, verb := range allVerbs {
-		verbSet.Add(verb)
-	}
-}
+var nounSet = mapset.NewSet[string](allNouns...)
+var verbSet = mapset.NewSet[string](allVerbs...)
 
 func (o *spaceBuilder) Entitlements(
 	ctx context.Context,
@@ -152,8 +143,7 @@ func (o *spaceBuilder) Entitlements(
 }
 
 // checkSpacePermission checks if the operation is in the list of operations we care about.
-// Confluence's API doesn't list all the operations you can do on a space, so we use a hard-coded list
-// This function checks if the operation is in the list of operations we care about
+// Confluence's API doesn't list all the operations you can do on a space, so we use a hard-coded list.
 func checkSpacePermission(operation, targetType string) bool {
 	return verbSet.Contains(operation) && nounSet.Contains(targetType)
 }

--- a/pkg/connector/spaces.go
+++ b/pkg/connector/spaces.go
@@ -188,7 +188,6 @@ func (o *spaceBuilder) Grants(
 					fmt.Sprintf("group:%s:member", permission.Principal.Id),
 				},
 			}))
-			fmt.Println(resource.Id.Resource, permission.Principal.Type, permission.Principal.Id, fmt.Sprintf("group:%s:member", permission.Principal.Id))
 		default:
 			// Skip if the type is "role".
 			continue

--- a/pkg/connector/spaces_test.go
+++ b/pkg/connector/spaces_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/conductorone/baton-confluence/pkg/connector/client"
-	"github.com/conductorone/baton-confluence/test"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-confluence/pkg/connector/client"
+	"github.com/conductorone/baton-confluence/test"
 )
 
 func TestSpaces(t *testing.T) {
@@ -27,7 +28,7 @@ func TestSpaces(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := newSpaceBuilder(confluenceClient)
+	c := newSpaceBuilder(confluenceClient, false)
 
 	t.Run("should list spaces", func(t *testing.T) {
 		resources := make([]*v2.Resource, 0)


### PR DESCRIPTION
- We currently emit a static set of entitlements for a Confluence space
- When listing grants, we call `GetSpacePermissions()` which can return permissions for things outside of our hardcoded set of entitlements
- This change will skip those permissions, and only emit grants for the permissions we know about.

## Note
Still need to test this, but I didn't have a confluence environment handy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new function for permission checking to enhance security and validation of operations.
	- Added new variables to manage valid nouns and verbs for improved operation handling.
	- Enhanced configuration options by allowing the option to skip personal spaces in the Confluence connector.

- **Bug Fixes**
	- Updated logic in the Grants method to filter out invalid permissions effectively.

- **Refactor**
	- Renamed function for clarity and improved code readability.
	- Enhanced organization and clarity in permission management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->