### PR TITLE
Fix for the entitlements/grants reduction

### DIFF
--- a/cmd/baton-confluence/main.go
+++ b/cmd/baton-confluence/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/field"
 	"github.com/conductorone/baton-sdk/pkg/types"
-	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -43,75 +41,11 @@ func main() {
 	}
 }
 
-var defaultNouns = []string{
-	"attachment",
-	"blogpost",
-	"comment",
-	"page",
-	"space",
-}
-
-var defaultVerbs = []string{
-	"administer",
-	"archive",
-	"create",
-	"delete",
-	"export",
-	"read",
-	"restrict_content",
-	"update",
-}
-
-func filterArgs(args, defaults []string) ([]string, error) {
-	var validArgs []string
-
-	argsSet := mapset.NewSet(args...)
-	defaultsSet := mapset.NewSet(defaults...)
-
-	// First, validate that all args from the cli are valid
-	for _, arg := range args {
-		if !defaultsSet.Contains(arg) {
-			return nil, fmt.Errorf("invalid input: %s", arg)
-		}
-	}
-
-	// If there were no flags on the cli, use the defaults
-	if argsSet.Cardinality() == 0 {
-		return defaults, nil
-	}
-
-	// Otherwise, grab words from the defaults in the right order
-	for _, arg := range defaults {
-		if argsSet.Contains(arg) {
-			validArgs = append(validArgs, arg)
-		}
-	}
-
-	// Just double check that validArgs actually has elements
-	if len(validArgs) == 0 {
-		return nil, errors.New("missing valid args")
-	}
-
-	return validArgs, nil
-}
-
 func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, error) {
 	l := ctxzap.Extract(ctx)
 
 	err := field.Validate(configuration, v)
 	if err != nil {
-		return nil, err
-	}
-
-	nouns, err := filterArgs(v.GetStringSlice(nounsField.FieldName), defaultNouns)
-	if err != nil {
-		l.Error("invalid nouns", zap.Error(err))
-		return nil, err
-	}
-
-	verbs, err := filterArgs(v.GetStringSlice(verbsField.FieldName), defaultVerbs)
-	if err != nil {
-		l.Error("invalid verbs", zap.Error(err))
 		return nil, err
 	}
 
@@ -121,8 +55,8 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 		v.GetString(domainUrl.FieldName),
 		v.GetString(usernameField.FieldName),
 		v.GetBool(skipPersonalSpaces.FieldName),
-		nouns,
-		verbs,
+		v.GetStringSlice(nounsField.FieldName),
+		v.GetStringSlice(verbsField.FieldName),
 	)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))


### PR DESCRIPTION
It's not exclusively a cli function, and we'll want to call it from elsewhere, so noun & verb filtering really belongs in the connector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added default noun and verb lists for input validation
	- Implemented input argument filtering and validation mechanism

- **Bug Fixes**
	- Enhanced error handling for noun and verb parameter inputs

The changes improve the robustness of argument processing by introducing default values and stricter validation for input parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->