### PR TITLE
Fix various issues when granting and revoking entitlements

### DIFF
--- a/pkg/connector/client/request.go
+++ b/pkg/connector/client/request.go
@@ -51,6 +51,7 @@ func (c *ConfluenceClient) makeRequest(
 
 	req.SetBasicAuth(c.user, c.apiKey)
 	req.Header.Set("X-Atlassian-Token", "no-check")
+	req.Header.Set("Content-Type", "application/json")
 
 	ratelimitData := v2.RateLimitDescription{}
 

--- a/pkg/connector/client/request.go
+++ b/pkg/connector/client/request.go
@@ -50,6 +50,7 @@ func (c *ConfluenceClient) makeRequest(
 	}
 
 	req.SetBasicAuth(c.user, c.apiKey)
+	req.Header.Set("X-Atlassian-Token", "no-check")
 
 	ratelimitData := v2.RateLimitDescription{}
 

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -183,8 +183,8 @@ func (o *groupResourceType) Grant(
 ) (annotations.Annotations, error) {
 	ratelimitData, err := o.client.AddUserToGroup(
 		ctx,
-		entitlement.Resource.Id.Resource,
 		principal.Id.Resource,
+		entitlement.Resource.Id.Resource,
 	)
 	outputAnnotations := WithRateLimitAnnotations(ratelimitData)
 	return outputAnnotations, err

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -196,8 +196,8 @@ func (o *groupResourceType) Revoke(
 ) (annotations.Annotations, error) {
 	ratelimitData, err := o.client.RemoveUserFromGroup(
 		ctx,
-		grant.Entitlement.Resource.Id.Resource,
 		grant.Principal.Id.Resource,
+		grant.Entitlement.Resource.Id.Resource,
 	)
 	outputAnnotations := WithRateLimitAnnotations(ratelimitData)
 	return outputAnnotations, err


### PR DESCRIPTION
This PR addresses issues found when calling the Confluence REST API when granting or revoking entitlements.
- Fails with 403 due to XSRF validation. This can be bypassed with a header.
- Fails with 415 when the Content-Type is not set or invalid.
- Fails with 404 when the groupid is invalid. In this case, the userid and groupid were swapped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced API communication by adding new header configurations for improved data handling.
- **Bug Fixes**
	- Adjusted the processing of group membership updates to ensure accurate user assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->