### PR TITLE
[BB-1744] Fix users not listing inactive

### DIFF
--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -36,9 +36,5 @@ func shouldIncludeUser(ctx context.Context, user client.ConfluenceUser) bool {
 		logger.Debug("confluence: user is not of type atlassian", zap.Any("user", user))
 		return false
 	}
-	if len(user.Operations) == 0 {
-		logger.Debug("confluence: user is deactivated (Unlicensed)", zap.Any("user", user))
-		return false
-	}
 	return true
 }

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -43,10 +43,15 @@ func userResource(ctx context.Context, user *client.ConfluenceUser) (*v2.Resourc
 		"id":           user.AccountId,
 	}
 
+	status := v2.UserTrait_Status_STATUS_ENABLED
+	if len(user.Operations) == 0 {
+		status = v2.UserTrait_Status_STATUS_DISABLED
+	}
+
 	userTraitOptions := []resource.UserTraitOption{
 		resource.WithUserProfile(profile),
 		resource.WithEmail(user.Email, true),
-		resource.WithStatus(v2.UserTrait_Status_STATUS_ENABLED),
+		resource.WithStatus(status),
 	}
 
 	newUserResource, err := resource.NewUserResource(

--- a/pkg/connector/user_test.go
+++ b/pkg/connector/user_test.go
@@ -15,7 +15,7 @@ import (
 func TestUsersList(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("should get users, using pagination, ignoring robots & deactivated", func(t *testing.T) {
+	t.Run("should get users, using pagination, ignoring robots but including deactivated", func(t *testing.T) {
 		server := test.FixturesServer()
 		defer server.Close()
 
@@ -57,14 +57,14 @@ func TestUsersList(t *testing.T) {
 
 		require.NotNil(t, resources)
 		// We expect there to be duplicates from users being in multiple groups
-		// and then showing up in User Search.
-		require.Len(t, resources, 6)
+		// and then showing up in User Search. Now includes deactivated users.
+		require.Len(t, resources, 7)
 		require.NotEmpty(t, resources[0].Id)
 
 		allIDs := mapset.NewSet[string]()
 		for _, resource := range resources {
 			allIDs.Add(resource.Id.Resource)
 		}
-		require.Equal(t, allIDs.Cardinality(), 2)
+		require.Equal(t, allIDs.Cardinality(), 3)
 	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Users with no operations are now included in processing and shown with a disabled status instead of being skipped.
* **Tests**
  * Test expectations updated to reflect inclusion of previously-skipped deactivated users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->