### PR TITLE
cxp-342 change default behavior

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -125,9 +125,13 @@ Self-hosted connector documentation coming soon.
 
 Each Confluence Space has its own set of permissions and allowed actions, which can result in a very large set of entitlement and grant access information in each Space. In order to reduce sync times, the Confluence connector only syncs a limited set of Spaces entitlements.
 
-By default, the Confluence connector syncs entitlements formed by valid pairs of the following targets (nouns) and operators (verbs), such as `administer-space` or `create-page`.
+By default, the Confluence connector syncs entitlements formed by valid pairs of the following targets (nouns) and operators (verbs), such as `administer-space` or `read-space`.
 
-Default targets (nouns):
+Default targets (nouns): `space`
+
+Default operators (verbs): `administer`, `create`, `delete`, `export`, `read`, `restrict_content`
+
+All available targets (nouns):
 
 - `attachment`
 - `blogpost`
@@ -135,7 +139,7 @@ Default targets (nouns):
 - `page`
 - `space`
 
-Default operators (verbs):
+All available operators (verbs):
 
 - `administer`
 - `archive`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,19 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/field"
 )
 
+var defaultNouns = []string{
+	"space",
+}
+
+var defaultVerbs = []string{
+	"administer",
+	"create",
+	"delete",
+	"export",
+	"read",
+	"restrict_content",
+}
+
 var (
 	apiKeyField = field.StringField(
 		"api-key",
@@ -37,12 +50,14 @@ var (
 		"noun",
 		field.WithDescription("The nouns for your Confluence Space sync"),
 		field.WithDisplayName("Nouns"),
+		field.WithDefaultValue(defaultNouns),
 		field.WithRequired(false),
 	)
 	verbsField = field.StringSliceField(
 		"verb",
 		field.WithDescription("The verbs for your Confluence Space sync"),
 		field.WithDisplayName("Verbs"),
+		field.WithDefaultValue(defaultVerbs),
 		field.WithRequired(false),
 	)
 )


### PR DESCRIPTION
To reduce the number of entitlements and grants we change the default to sync ONLY "space" relevant actions. This focuses in space permissions, omitting target (page, blogpost, attachments...) specific permissions

Since this changes the default values for configs, we will need to do a MIGRATION in order to keep existing customers with the current behavior