### PR TITLE
cxp-423 add rbac support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,15 @@ baton resources
 - Groups
 - Users
 
-## Space Permissions
-Every Confluence space has its own set of permissions which determine what
-people can do in the space.
+## Space Permissions and RBAC Space Roles
 
-These permissions are Entitlements for Spaces and are represented as a pair of
-"operation" and "target".
+Confluence is transitioning to an RBAC model for space access control. The
+connector supports both modes.
+
+### Granular Space Permissions (default)
+
+By default, the connector syncs granular space permissions as Entitlements.
+Each permission is represented as a pair of "operation" and "target".
 
 Valid targets include:
 - `application`
@@ -88,6 +91,16 @@ Not all operation-target pairs are valid, but here are some examples of valid on
 
 See [Space Permissions Overview documentation page](https://confluence.atlassian.com/doc/space-permissions-overview-139521.html).
 
+### RBAC Space Roles
+
+When `--use-rbac` is set, the connector instead syncs Confluence RBAC space
+roles as Entitlements. Role assignments to users and groups are synced as
+Grants, and provisioning (grant/revoke) operates on role assignments.
+
+Use this mode when your Confluence instance has space roles enabled and you
+want to manage access through Confluence's newer RBAC model rather than
+granular permissions.
+
 # Contributing, Support and Issues
 
 We started Baton because we were tired of taking screenshots and manually
@@ -125,6 +138,7 @@ Flags:
       --skip-full-sync         This must be set to skip a full sync ($BATON_SKIP_FULL_SYNC)
       --skip-personal-spaces   Skip syncing personal spaces and their permissions ($BATON_SKIP_PERSONAL_SPACES)
       --ticketing              This must be set to enable ticketing support ($BATON_TICKETING)
+      --use-rbac               Use Confluence RBAC space roles instead of granular space permissions ($BATON_USE_RBAC)
       --username string        required: The username for your Confluence account ($BATON_USERNAME)
       --verb strings           The verbs for your Confluence Space sync ($BATON_VERB)
   -v, --version                version for baton-confluence

--- a/cmd/baton-confluence/main.go
+++ b/cmd/baton-confluence/main.go
@@ -53,6 +53,7 @@ func getConnector(ctx context.Context, config *cfg.Confluence) (types.ConnectorS
 		config.DomainUrl,
 		config.Username,
 		config.SkipPersonalSpaces,
+		config.UseRbac,
 		config.Noun,
 		config.Verb,
 	)

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -18,6 +18,11 @@ sidebarTitle: "Atlassian Confluence"
 | Groups | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Spaces | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
 | Space permissions | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+| Space roles (RBAC) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+
+<Note>
+Space permissions and space roles are mutually exclusive. By default, the connector syncs granular space permissions. Enable the **Use RBAC** setting to sync RBAC space roles instead. See [Confluence RBAC space roles](#confluence-rbac-space-roles) for details.
+</Note>
 
 <Tip>
 To limit sync times, a limited list of Spaces entitlements and their associated grants are synced. See the [Spaces entitlements synced by default](/baton/confluence#spaces-entitlements-synced-by-default) section of this page for more information.
@@ -103,6 +108,9 @@ A user with **Administrator** access in Confluence must perform this task.
     </Step>
     <Step>
     **Optional.** If want to sync information on Confluence users' personal spaces and their permissions, uncheck the **Skip syncing personal spaces and their permissions** box.
+    </Step>
+    <Step>
+    **Optional.** If your Confluence instance uses RBAC space roles, enable the **Use RBAC** setting to sync space roles instead of granular space permissions. See [Confluence RBAC space roles](#confluence-rbac-space-roles) for details.
     </Step>
     <Step>
     Click **Save**.
@@ -268,4 +276,13 @@ Not all target-operator (noun-verb) pairs are valid.
 
 To change or limit what the Confluence connector syncs to C1, use the `--noun` and `--verb` flags when setting up the Confluence connector in self-hosted mode. See the [baton-confluence repo's README](https://github.com/conductorone/baton-confluence) for more information.
 
+## Confluence RBAC space roles
+
+Confluence is transitioning to a role-based access control (RBAC) model for space permissions. The Confluence connector supports both the legacy granular permissions model and the newer RBAC model.
+
+When the **Use RBAC** setting (or the `--use-rbac` flag in self-hosted mode) is enabled, the connector syncs **space roles** as entitlements rather than granular operation-target permission pairs. Role assignments to users and groups are synced as grants. Provisioning (granting and revoking access) operates on space role assignments.
+
+<Note>
+Space permissions and RBAC space roles are mutually exclusive. Enable **Use RBAC** only if your Confluence instance has space roles active. When in doubt, leave this setting disabled to use the default granular permissions model.
+</Note>
 

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -10,6 +10,7 @@ type Confluence struct {
 	SkipPersonalSpaces bool `mapstructure:"skip-personal-spaces"`
 	Noun []string `mapstructure:"noun"`
 	Verb []string `mapstructure:"verb"`
+	UseRbac bool `mapstructure:"use-rbac"`
 }
 
 func (c *Confluence) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,12 @@ var (
 		field.WithDisplayName("Verbs"),
 		field.WithRequired(false),
 	)
+	useRbacField = field.BoolField(
+		"use-rbac",
+		field.WithDescription("Use Confluence RBAC space roles instead of granular space permissions"),
+		field.WithDisplayName("Use RBAC"),
+		field.WithDefaultValue(false),
+	)
 )
 
 var ConfigurationFields = []field.SchemaField{
@@ -54,6 +60,7 @@ var ConfigurationFields = []field.SchemaField{
 	skipPersonalSpaces,
 	nounsField,
 	verbsField,
+	useRbacField,
 }
 
 var Configuration = field.NewConfiguration(

--- a/pkg/connector/client/confluence.go
+++ b/pkg/connector/client/confluence.go
@@ -95,6 +95,30 @@ func (c *ConfluenceClient) Verify(ctx context.Context) error {
 	return nil
 }
 
+// VerifyRbac validates credentials by hitting the v2 space-role-mode endpoint.
+// Use this instead of Verify when the connector is configured for RBAC mode,
+// as those credentials may only have access to the v2 API.
+func (c *ConfluenceClient) VerifyRbac(ctx context.Context) error {
+	spaceRoleModeUrl, err := c.parse(SpaceRoleModeUrlPath)
+	if err != nil {
+		return err
+	}
+
+	var response *SpaceRoleModeResponse
+	_, err = c.get(ctx, spaceRoleModeUrl, &response)
+	if err != nil {
+		return err
+	}
+
+	// Valid values: ROLES_TRANSITION, ROLES. If the mode is PRE_ROLE, then RBAC is not enabled for this Confluence instance.
+	// https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-space-roles/#api-space-role-mode-get
+	if response.Mode == "PRE_ROLE" {
+		return fmt.Errorf("confluence-connector: space role mode is %q — RBAC is not enabled for this Confluence instance", response.Mode)
+	}
+
+	return nil
+}
+
 func isThereAnotherPage(links ConfluenceLink) bool {
 	return links.Next != ""
 }
@@ -568,6 +592,111 @@ func extractPaginationCursor(links ConfluenceLink) string {
 		return ""
 	}
 	return parsedUrl.Query().Get("cursor")
+}
+
+// GetSpaceRoles fetches space roles from the v2 API, optionally filtered by spaceId.
+func (c *ConfluenceClient) GetSpaceRoles(
+	ctx context.Context,
+	spaceId string,
+	cursor string,
+	pageSize int,
+) (
+	[]SpaceRole,
+	string,
+	*v2.RateLimitDescription,
+	error,
+) {
+	options := []Option{withPaginationCursor(pageSize, cursor)}
+	if spaceId != "" {
+		options = append(options, withQueryParameters(map[string]interface{}{"space-id": spaceId}))
+	}
+
+	spaceRolesUrl, err := c.parse(SpaceRolesUrlPath, options...)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	var response *SpaceRolesResponse
+	ratelimitData, err := c.get(ctx, spaceRolesUrl, &response)
+	if err != nil {
+		return nil, "", ratelimitData, err
+	}
+
+	nextCursor := extractPaginationCursor(response.Links)
+	return response.Results, nextCursor, ratelimitData, nil
+}
+
+// GetSpaceRoleAssignments fetches role assignments for a given space.
+// roleId, principalId, and principalType are optional filters; pass empty string to omit.
+func (c *ConfluenceClient) GetSpaceRoleAssignments(
+	ctx context.Context,
+	spaceId string,
+	roleId string,
+	principalId string,
+	principalType string,
+	cursor string,
+	pageSize int,
+) (
+	[]SpaceRoleAssignment,
+	string,
+	*v2.RateLimitDescription,
+	error,
+) {
+	options := []Option{withPaginationCursor(pageSize, cursor)}
+	if roleId != "" {
+		options = append(options, withQueryParameters(map[string]interface{}{"role-id": roleId}))
+	}
+	if principalId != "" {
+		options = append(options, withQueryParameters(map[string]interface{}{"principal-id": principalId}))
+	}
+	if principalType != "" {
+		options = append(options, withQueryParameters(map[string]interface{}{"principal-type": principalType}))
+	}
+
+	assignmentsUrl, err := c.parse(
+		fmt.Sprintf(SpaceRoleAssignmentsUrlPath, url.PathEscape(spaceId)),
+		options...,
+	)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	var response *SpaceRoleAssignmentsResponse
+	ratelimitData, err := c.get(ctx, assignmentsUrl, &response)
+	if err != nil {
+		return nil, "", ratelimitData, err
+	}
+
+	nextCursor := extractPaginationCursor(response.Links)
+	return response.Results, nextCursor, ratelimitData, nil
+}
+
+// SetSpaceRoleAssignment adds role assignments for a space.
+func (c *ConfluenceClient) SetSpaceRoleAssignment(
+	ctx context.Context,
+	spaceId string,
+	assignments []SetSpaceRoleAssignmentRequest,
+) (
+	*v2.RateLimitDescription,
+	error,
+) {
+	assignmentsUrl, err := c.parse(fmt.Sprintf(SpaceRoleAssignmentsUrlPath, url.PathEscape(spaceId)))
+	if err != nil {
+		return nil, err
+	}
+
+	bodyBytes, err := json.Marshal(assignments)
+	if err != nil {
+		return nil, err
+	}
+
+	body := strings.NewReader(string(bodyBytes))
+	var response SpaceRoleAssignmentsResponse
+	ratelimitData, err := c.post(ctx, assignmentsUrl, &response, body)
+	if err != nil {
+		return ratelimitData, err
+	}
+	return ratelimitData, nil
 }
 
 // GetUsersFromSearch There are no official, documented ways to get lists of

--- a/pkg/connector/client/models.go
+++ b/pkg/connector/client/models.go
@@ -138,3 +138,40 @@ type CreateSpacePermissionRequestBody struct {
 type AddUserToGroupRequestBody struct {
 	AccountId string `json:"accountId"`
 }
+
+type SpaceRole struct {
+	Id               string   `json:"id"`
+	Type             string   `json:"type"`
+	Name             string   `json:"name"`
+	Description      string   `json:"description"`
+	SpacePermissions []string `json:"spacePermissions"`
+}
+
+type SpaceRoleAssignmentPrincipal struct {
+	PrincipalType string `json:"principalType"`
+	PrincipalId   string `json:"principalId"`
+}
+
+type SpaceRoleAssignment struct {
+	Principal SpaceRoleAssignmentPrincipal `json:"principal"`
+	RoleId    string                       `json:"roleId"`
+}
+
+type SpaceRolesResponse struct {
+	Results []SpaceRole    `json:"results"`
+	Links   ConfluenceLink `json:"_links"`
+}
+
+type SpaceRoleAssignmentsResponse struct {
+	Results []SpaceRoleAssignment `json:"results"`
+	Links   ConfluenceLink        `json:"_links"`
+}
+
+type SpaceRoleModeResponse struct {
+	Mode string `json:"mode"`
+}
+
+type SetSpaceRoleAssignmentRequest struct {
+	Principal SpaceRoleAssignmentPrincipal `json:"principal"`
+	RoleId    string                       `json:"roleId,omitempty"`
+}

--- a/pkg/connector/client/path.go
+++ b/pkg/connector/client/path.go
@@ -17,6 +17,9 @@ const (
 	SpacesListUrlPath             = "/wiki/api/v2/spaces"
 	spacesGetUrlPath              = "/wiki/api/v2/spaces/%s"
 	SpacePermissionsListUrlPath   = "/wiki/api/v2/spaces/%s/permissions"
+	SpaceRolesUrlPath             = "/wiki/api/v2/space-roles"
+	SpaceRoleAssignmentsUrlPath   = "/wiki/api/v2/spaces/%s/role-assignments"
+	SpaceRoleModeUrlPath          = "/wiki/api/v2/space-role-mode"
 
 	defaultSize = 100
 )

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -52,6 +52,7 @@ type Confluence struct {
 	apiKey             string
 	userName           string
 	skipPersonalSpaces bool
+	useRbac            bool
 	nouns              []string
 	verbs              []string
 }
@@ -114,6 +115,7 @@ func New(
 	domainUrl string,
 	username string,
 	skipPersonalSpaces bool,
+	useRbac bool,
 	nouns []string,
 	verbs []string,
 ) (*Confluence, error) {
@@ -138,6 +140,7 @@ func New(
 		userName:           username,
 		client:             client,
 		skipPersonalSpaces: skipPersonalSpaces,
+		useRbac:            useRbac,
 		nouns:              filteredNouns,
 		verbs:              filteredVerbs,
 	}
@@ -158,7 +161,12 @@ func (c *Confluence) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error
 }
 
 func (c *Confluence) Validate(ctx context.Context) (annotations.Annotations, error) {
-	err := c.client.Verify(ctx)
+	var err error
+	if c.useRbac {
+		err = c.client.VerifyRbac(ctx)
+	} else {
+		err = c.client.Verify(ctx)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("confluence-connector: failed to validate API keys: %w", err)
 	}
@@ -174,6 +182,6 @@ func (c *Confluence) ResourceSyncers(ctx context.Context) []connectorbuilder.Res
 	return []connectorbuilder.ResourceSyncer{
 		groupBuilder(c.client),
 		userBuilder(c.client),
-		newSpaceBuilder(c.client, c.skipPersonalSpaces, c.nouns, c.verbs),
+		newSpaceBuilder(c.client, c.skipPersonalSpaces, c.useRbac, c.nouns, c.verbs),
 	}
 }

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -2,10 +2,12 @@ package connector
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/conductorone/baton-confluence/pkg/connector/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 )
@@ -39,4 +41,29 @@ func shouldIncludeUser(ctx context.Context, user client.ConfluenceUser) bool {
 		return false
 	}
 	return true
+}
+
+func confluencePrincipalType(resourceTypeId string) (string, error) {
+	switch resourceTypeId {
+	case "user":
+		return "USER", nil
+	case "group":
+		return "GROUP", nil
+	}
+	return "", fmt.Errorf("unsupported principal resource type: %s", resourceTypeId)
+}
+
+func NewPermissionEntitlement(resource *v2.Resource, id string, name string, entitlementOptions ...entitlement.EntitlementOption) *v2.Entitlement {
+	entitlement := v2.Entitlement_builder{
+		Id:          entitlement.NewEntitlementID(resource, id),
+		DisplayName: name,
+		Slug:        name,
+		Purpose:     v2.Entitlement_PURPOSE_VALUE_PERMISSION,
+		Resource:    resource,
+	}.Build()
+
+	for _, entitlementOption := range entitlementOptions {
+		entitlementOption(entitlement)
+	}
+	return entitlement
 }

--- a/pkg/connector/spaces.go
+++ b/pkg/connector/spaces.go
@@ -36,6 +36,7 @@ func GetEntitlementComponents(operation string) (string, string) {
 type spaceBuilder struct {
 	client             client.ConfluenceClient
 	skipPersonalSpaces bool
+	useRbac            bool
 	nouns              []string
 	verbs              []string
 }
@@ -83,7 +84,7 @@ func (o *spaceBuilder) List(
 
 func (o *spaceBuilder) Entitlements(
 	ctx context.Context,
-	resource *v2.Resource,
+	res *v2.Resource,
 	pToken *pagination.Token,
 ) (
 	[]*v2.Entitlement,
@@ -91,6 +92,32 @@ func (o *spaceBuilder) Entitlements(
 	annotations.Annotations,
 	error,
 ) {
+	if o.useRbac {
+		roles, nextCursor, ratelimitData, err := o.client.GetSpaceRoles(
+			ctx,
+			"",
+			pToken.Token,
+			ResourcesPageSize,
+		)
+		outputAnnotations := WithRateLimitAnnotations(ratelimitData)
+		if err != nil {
+			return nil, "", outputAnnotations, fmt.Errorf("confluence-connector: failed to list space roles: %w", err)
+		}
+
+		var entitlements []*v2.Entitlement
+		for _, role := range roles {
+			entitlements = append(entitlements, NewPermissionEntitlement(
+				res,
+				role.Id,
+				role.Name,
+				entitlement.WithGrantableTo(resourceTypeUser, resourceTypeGroup),
+				entitlement.WithDisplayName(fmt.Sprintf("%s role", role.Name)),
+				entitlement.WithDescription(fmt.Sprintf("Has the %s role in Confluence space %s", role.Name, res.DisplayName)),
+			))
+		}
+		return entitlements, nextCursor, outputAnnotations, nil
+	}
+
 	entitlements := make([]*v2.Entitlement, 0)
 
 	for _, noun := range o.nouns {
@@ -99,7 +126,7 @@ func (o *spaceBuilder) Entitlements(
 			entitlements = append(
 				entitlements,
 				entitlement.NewPermissionEntitlement(
-					resource,
+					res,
 					operationName,
 					entitlement.WithGrantableTo(resourceTypeUser),
 					entitlement.WithGrantableTo(resourceTypeGroup),
@@ -107,7 +134,7 @@ func (o *spaceBuilder) Entitlements(
 						fmt.Sprintf(
 							"Can %s %s",
 							operationName,
-							resource.DisplayName,
+							res.DisplayName,
 						),
 					),
 					entitlement.WithDescription(
@@ -115,7 +142,7 @@ func (o *spaceBuilder) Entitlements(
 							"Has permission to %s %s the %s space in Confluence",
 							verb,
 							noun,
-							resource.DisplayName,
+							res.DisplayName,
 						),
 					),
 				))
@@ -130,10 +157,9 @@ func checkSpacePermission(nouns mapset.Set[string], verbs mapset.Set[string], op
 	return verbs.Contains(operation) && nouns.Contains(targetType)
 }
 
-// Grants the grants for a given space are the permissions.
 func (o *spaceBuilder) Grants(
 	ctx context.Context,
-	resource *v2.Resource,
+	res *v2.Resource,
 	pToken *pagination.Token,
 ) (
 	[]*v2.Grant,
@@ -141,11 +167,59 @@ func (o *spaceBuilder) Grants(
 	annotations.Annotations,
 	error,
 ) {
+	if o.useRbac {
+		assignments, nextCursor, ratelimitData, err := o.client.GetSpaceRoleAssignments(
+			ctx,
+			res.Id.Resource,
+			"",
+			"",
+			"",
+			pToken.Token,
+			pToken.Size,
+		)
+		outputAnnotations := WithRateLimitAnnotations(ratelimitData)
+		if err != nil {
+			return nil, "", outputAnnotations, fmt.Errorf("confluence-connector: failed to list space role assignments: %w", err)
+		}
+
+		var grants []*v2.Grant
+		for _, assignment := range assignments {
+			var resourceType string
+			var grantOpts []grantSdk.GrantOption
+
+			switch assignment.Principal.PrincipalType {
+			case "USER":
+				resourceType = resourceTypeUser.Id
+			case "GROUP":
+				resourceType = resourceTypeGroup.Id
+				grantOpts = append(grantOpts, grantSdk.WithAnnotation(&v2.GrantExpandable{
+					EntitlementIds: []string{
+						fmt.Sprintf("group:%s:member", assignment.Principal.PrincipalId),
+					},
+				}))
+			default:
+				continue
+			}
+
+			grants = append(grants, grantSdk.NewGrant(
+				res,
+				assignment.RoleId,
+				&v2.ResourceId{
+					ResourceType: resourceType,
+					Resource:     assignment.Principal.PrincipalId,
+				},
+				grantOpts...,
+			))
+		}
+
+		return grants, nextCursor, outputAnnotations, nil
+	}
+
 	permissionsList, nextToken, ratelimitData, err := o.client.GetSpacePermissions(
 		ctx,
 		pToken.Token,
 		pToken.Size,
-		resource.Id.Resource,
+		res.Id.Resource,
 	)
 	outputAnnotations := WithRateLimitAnnotations(ratelimitData)
 	if err != nil {
@@ -155,7 +229,7 @@ func (o *spaceBuilder) Grants(
 	nounsSet := mapset.NewSet(o.nouns...)
 	verbsSet := mapset.NewSet(o.verbs...)
 
-	var permissions []*v2.Grant
+	var grants []*v2.Grant
 	for _, permission := range permissionsList {
 		grantOpts := []grantSdk.GrantOption{}
 		var resourceType string
@@ -170,36 +244,72 @@ func (o *spaceBuilder) Grants(
 				},
 			}))
 		default:
-			// Skip if the type is "role".
 			continue
 		}
-
 		if !checkSpacePermission(nounsSet, verbsSet, permission.Operation.Key, permission.Operation.TargetType) {
 			continue
 		}
-
-		grant := grantSdk.NewGrant(
-			resource,
+		grants = append(grants, grantSdk.NewGrant(
+			res,
 			createEntitlementName(permission.Operation.Key, permission.Operation.TargetType),
-			&v2.ResourceId{
-				ResourceType: resourceType,
-				Resource:     permission.Principal.Id,
-			},
+			&v2.ResourceId{ResourceType: resourceType, Resource: permission.Principal.Id},
 			grantOpts...,
-		)
-		permissions = append(permissions, grant)
+		))
 	}
 
-	return permissions, nextToken, outputAnnotations, nil
+	return grants, nextToken, outputAnnotations, nil
 }
 
 func (o *spaceBuilder) Grant(
 	ctx context.Context,
 	principal *v2.Resource,
-	entitlement *v2.Entitlement,
+	ent *v2.Entitlement,
 ) (annotations.Annotations, error) {
-	spaceName := entitlement.Resource.Id.Resource
-	key, target := GetEntitlementComponents(entitlement.Slug)
+	if o.useRbac {
+		spaceId := ent.Resource.Id.Resource
+		parts := strings.SplitN(ent.Id, ":", 3)
+		if len(parts) < 3 {
+			return nil, fmt.Errorf("confluence-connector: invalid entitlement ID: %q", ent.Id)
+		}
+		roleId := parts[2]
+
+		principalType, err := confluencePrincipalType(principal.Id.ResourceType)
+		if err != nil {
+			return nil, fmt.Errorf("confluence-connector: %w", err)
+		}
+
+		principalId := principal.Id.Resource
+
+		existing, _, _, err := o.client.GetSpaceRoleAssignments(ctx, spaceId, roleId, principalId, principalType, "", 1)
+		if err != nil {
+			return nil, fmt.Errorf("confluence-connector: failed to check existing role assignments: %w", err)
+		}
+		if len(existing) > 0 {
+			return annotations.New(&v2.GrantAlreadyExists{}), nil
+		}
+
+		ratelimitData, err := o.client.SetSpaceRoleAssignment(
+			ctx,
+			spaceId,
+			[]client.SetSpaceRoleAssignmentRequest{
+				{
+					Principal: client.SpaceRoleAssignmentPrincipal{
+						PrincipalType: principalType,
+						PrincipalId:   principalId,
+					},
+					RoleId: roleId,
+				},
+			},
+		)
+		outputAnnotations := WithRateLimitAnnotations(ratelimitData)
+		if err != nil {
+			return outputAnnotations, fmt.Errorf("confluence-connector: failed to grant space role: %w", err)
+		}
+		return outputAnnotations, nil
+	}
+
+	spaceName := ent.Resource.Id.Resource
+	key, target := GetEntitlementComponents(ent.Slug)
 	ratelimitData, err := o.client.AddSpacePermission(
 		ctx,
 		spaceName,
@@ -216,6 +326,49 @@ func (o *spaceBuilder) Revoke(
 	ctx context.Context,
 	grant *v2.Grant,
 ) (annotations.Annotations, error) {
+	if o.useRbac {
+		spaceId := grant.Entitlement.Resource.Id.Resource
+		parts := strings.SplitN(grant.Entitlement.Id, ":", 3)
+		if len(parts) < 3 {
+			return nil, fmt.Errorf("confluence-connector: invalid entitlement ID: %q", grant.Entitlement.Id)
+		}
+		roleId := parts[2]
+
+		principalType, err := confluencePrincipalType(grant.Principal.Id.ResourceType)
+		if err != nil {
+			return nil, fmt.Errorf("confluence-connector: %w", err)
+		}
+
+		principalId := grant.Principal.Id.Resource
+
+		existing, _, _, err := o.client.GetSpaceRoleAssignments(ctx, spaceId, roleId, principalId, principalType, "", 1)
+		if err != nil {
+			return nil, fmt.Errorf("confluence-connector: failed to check existing role assignments: %w", err)
+		}
+		if len(existing) == 0 {
+			return annotations.New(&v2.GrantAlreadyRevoked{}), nil
+		}
+
+		ratelimitData, err := o.client.SetSpaceRoleAssignment(
+			ctx,
+			spaceId,
+			[]client.SetSpaceRoleAssignmentRequest{
+				{
+					Principal: client.SpaceRoleAssignmentPrincipal{
+						PrincipalType: principalType,
+						PrincipalId:   principalId,
+					},
+					// RoleId intentionally omitted: signals removal to the API
+				},
+			},
+		)
+		outputAnnotations := WithRateLimitAnnotations(ratelimitData)
+		if err != nil {
+			return outputAnnotations, fmt.Errorf("confluence-connector: failed to revoke space role: %w", err)
+		}
+		return outputAnnotations, nil
+	}
+
 	spaceId := grant.Entitlement.Resource.Id.Resource
 	key, target := GetEntitlementComponents(grant.Entitlement.Slug)
 	ratelimitData, err := o.client.RemoveSpacePermission(
@@ -230,24 +383,20 @@ func (o *spaceBuilder) Revoke(
 	return outputAnnotations, err
 }
 
-func newSpaceBuilder(client *client.ConfluenceClient, skipPersonalSpaces bool, nouns, verbs []string) *spaceBuilder {
+func newSpaceBuilder(client *client.ConfluenceClient, skipPersonalSpaces bool, useRbac bool, nouns, verbs []string) *spaceBuilder {
 	return &spaceBuilder{
 		client:             *client,
 		skipPersonalSpaces: skipPersonalSpaces,
+		useRbac:            useRbac,
 		nouns:              nouns,
 		verbs:              verbs,
 	}
 }
 
 func spaceResource(ctx context.Context, space *client.ConfluenceSpace) (*v2.Resource, error) {
-	createdResource, err := resource.NewResource(
+	return resource.NewResource(
 		space.Name,
 		spaceResourceType,
 		space.Id,
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	return createdResource, nil
 }

--- a/pkg/connector/spaces_test.go
+++ b/pkg/connector/spaces_test.go
@@ -31,6 +31,7 @@ func TestSpaces(t *testing.T) {
 	c := newSpaceBuilder(
 		confluenceClient,
 		false,
+		false,
 		[]string{
 			"attachment",
 			"blogpost",
@@ -81,5 +82,52 @@ func TestSpaces(t *testing.T) {
 		test.AssertNoRatelimitAnnotations(t, grantsAnnotations)
 		require.Equal(t, "", nextToken)
 		require.Len(t, grants, 25)
+	})
+}
+
+func TestSpacesRbac(t *testing.T) {
+	ctx := context.Background()
+	server := test.FixturesServer()
+	defer server.Close()
+
+	confluenceClient, err := client.NewConfluenceClient(ctx, "username", "API Key", server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := newSpaceBuilder(confluenceClient, false, true, nil, nil)
+
+	t.Run("should list role entitlements for a space", func(t *testing.T) {
+		confluenceSpace := client.ConfluenceSpace{Id: "678", Name: "Product Management"}
+		space, _ := spaceResource(ctx, &confluenceSpace)
+
+		entitlements, nextToken, annotations, err := c.Entitlements(ctx, space, &pagination.Token{})
+		require.Nil(t, err)
+		test.AssertNoRatelimitAnnotations(t, annotations)
+		require.Equal(t, "", nextToken)
+		require.Len(t, entitlements, 3)
+
+		require.Equal(t, "space:678:role-001", entitlements[0].Id)
+		require.Equal(t, "Viewer", entitlements[0].Slug)
+		require.Equal(t, "Viewer role", entitlements[0].DisplayName)
+	})
+
+	t.Run("should list role assignment grants for a space", func(t *testing.T) {
+		confluenceSpace := client.ConfluenceSpace{Id: "678"}
+		space, _ := spaceResource(ctx, &confluenceSpace)
+
+		grants, nextToken, annotations, err := c.Grants(ctx, space, &pagination.Token{})
+		require.Nil(t, err)
+		test.AssertNoRatelimitAnnotations(t, annotations)
+		require.Equal(t, "", nextToken)
+		require.Len(t, grants, 3)
+
+		require.Equal(t, "space:678:role-001", grants[0].Entitlement.Id)
+		require.Equal(t, "user-123", grants[0].Principal.Id.Resource)
+		require.Equal(t, resourceTypeUser.Id, grants[0].Principal.Id.ResourceType)
+
+		require.Equal(t, "space:678:role-002", grants[1].Entitlement.Id)
+		require.Equal(t, "group-456", grants[1].Principal.Id.Resource)
+		require.Equal(t, resourceTypeGroup.Id, grants[1].Principal.Id.ResourceType)
 	})
 }

--- a/test/fixtures/role_assignments0.json
+++ b/test/fixtures/role_assignments0.json
@@ -1,0 +1,17 @@
+{
+  "results": [
+    {
+      "principal": {"principalType": "USER", "principalId": "user-123"},
+      "roleId": "role-001"
+    },
+    {
+      "principal": {"principalType": "GROUP", "principalId": "group-456"},
+      "roleId": "role-002"
+    },
+    {
+      "principal": {"principalType": "USER", "principalId": "user-789"},
+      "roleId": "role-003"
+    }
+  ],
+  "_links": {}
+}

--- a/test/fixtures/space_roles.json
+++ b/test/fixtures/space_roles.json
@@ -1,0 +1,26 @@
+{
+  "results": [
+    {
+      "id": "role-001",
+      "type": "DEFAULT",
+      "name": "Viewer",
+      "description": "View content in spaces",
+      "spacePermissions": ["read-space"]
+    },
+    {
+      "id": "role-002",
+      "type": "DEFAULT",
+      "name": "Editor",
+      "description": "Create and edit content in spaces",
+      "spacePermissions": ["read-space", "create-page"]
+    },
+    {
+      "id": "role-003",
+      "type": "DEFAULT",
+      "name": "Admin",
+      "description": "Administer spaces",
+      "spacePermissions": ["read-space", "create-page", "administer-space"]
+    }
+  ],
+  "_links": {}
+}

--- a/test/testhelpers.go
+++ b/test/testhelpers.go
@@ -63,6 +63,10 @@ func FixturesServer() *httptest.Server {
 					filename = "../../test/fixtures/groups1.json"
 				case strings.Contains(routeUrl, client.GroupsListUrlPath):
 					filename = "../../test/fixtures/groups0.json"
+				case strings.Contains(routeUrl, "role-assignments"):
+					filename = "../../test/fixtures/role_assignments0.json"
+				case strings.Contains(routeUrl, client.SpaceRolesUrlPath):
+					filename = "../../test/fixtures/space_roles.json"
 				case strings.Contains(routeUrl, client.SpacesListUrlPath) && strings.Contains(routeUrl, "permissions"):
 					filename = "../../test/fixtures/permissions0.json"
 				case strings.Contains(routeUrl, client.SpacesListUrlPath) && strings.Contains(routeUrl, "cursor"):


### PR DESCRIPTION
Confluence is transitioning to RBAC model, we add support for space roles as entitlements, replacing the current granular permissions model.