### PR TITLE
docs: add self-hosted connector instructions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -115,9 +115,127 @@ A user with **Administrator** access in Confluence must perform this task.
 **That's it!** Your Confluence connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
-**Follow these instructions to use the Confluence connector, hosted and run in your own environment.**
+Follow these instructions to use the [Confluence](https://github.com/conductorone/baton-confluence) connector, hosted and run in your own environment.
 
-Self-hosted connector documentation coming soon.
+When running in service mode on Kubernetes, a self-hosted connector maintains an ongoing connection with C1, automatically syncing and uploading data at regular intervals. This data is immediately available in the C1 UI for access reviews and access requests.
+
+### Resources
+
+* [Official download center](https://dist.conductorone.com/ConductorOne/baton-confluence): For stable binaries (Windows/Linux/macOS) and container images.
+
+* [GitHub repository](https://github.com/conductorone/baton-confluence): Access the source code, report issues, or contribute to the project.
+
+### Step 1: Set up a new Confluence connector
+
+<Steps>
+    <Step>
+    In C1, navigate to **Integrations** > **Connectors** > **Add connector**.
+    </Step>
+    <Step>
+    Search for **Baton** and click **Add**.
+    </Step>
+    <Step>
+    Choose how to set up the new Confluence connector:
+
+    - Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with C1)
+    - Add the connector to a managed app (select from the list of existing managed apps)
+    - Create a new managed app
+    </Step>
+    <Step>
+    Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of C1 users. Setting multiple owners is allowed.
+
+    If you choose someone else, C1 will notify the new connector owner by email that their help is needed to complete the setup process.
+    </Step>
+    <Step>
+    Click **Next**.
+    </Step>
+    <Step>
+    In the **Settings** area of the page, click **Edit**.
+    </Step>
+    <Step>
+    Click **Rotate** to generate a new Client ID and Secret.
+
+    Carefully copy and save these credentials. We'll use them in Step 2.
+    </Step>
+</Steps>
+
+### Step 2: Create Kubernetes configuration files
+
+Create two Kubernetes manifest files for your Confluence connector deployment:
+
+#### Secrets configuration
+
+```yaml expandable
+# baton-confluence-secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: baton-confluence-secrets
+type: Opaque
+stringData:
+  # C1 credentials
+  BATON_CLIENT_ID: <C1 client ID>
+  BATON_CLIENT_SECRET: <C1 client secret>
+
+  # Confluence credentials
+  BATON_DOMAIN_URL: <Confluence site domain URL (e.g. https://your-domain.atlassian.net)>
+  BATON_USERNAME: <Username for your Confluence account>
+  BATON_API_KEY: <Confluence API token>
+
+  # Optional: include if you want C1 to provision access using this connector
+  BATON_PROVISIONING: true
+
+  # Optional: include to skip syncing personal spaces and their permissions
+  BATON_SKIP_PERSONAL_SPACES: true
+```
+
+See the connector's README or run `--help` to see all available configuration flags and environment variables.
+
+#### Deployment configuration
+
+```yaml expandable
+# baton-confluence.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baton-confluence
+  labels:
+    app: baton-confluence
+spec:
+  selector:
+    matchLabels:
+      app: baton-confluence
+  template:
+    metadata:
+      labels:
+        app: baton-confluence
+        baton: true
+        baton-app: confluence
+    spec:
+      containers:
+      - name: baton-confluence
+        image: ghcr.io/conductorone/baton-confluence:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: BATON_HOST_ID
+          value: baton-confluence
+        envFrom:
+        - secretRef:
+            name: baton-confluence-secrets
+```
+
+### Step 3: Deploy the connector
+
+<Steps>
+    <Step>
+    Create a namespace in which to run C1 connectors (if desired), then apply the secret config and deployment config files.
+    </Step>
+    <Step>
+    Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the Confluence connector to. Confluence data should be found on the **Entitlements** and **Accounts** tabs.
+    </Step>
+</Steps>
+
+**That's it!** Your Confluence connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -178,7 +178,7 @@ stringData:
   BATON_CLIENT_SECRET: <C1 client secret>
 
   # Confluence credentials
-  BATON_DOMAIN_URL: <Confluence site domain URL (e.g. https://your-domain.atlassian.net)>
+  BATON_DOMAIN_URL: <Confluence site domain URL (for example, https://your-domain.atlassian.net)>
   BATON_USERNAME: <Username for your Confluence account>
   BATON_API_KEY: <Confluence API token>
 


### PR DESCRIPTION
Replaces the "coming soon" placeholder in the Self-hosted tab of `docs/connector.mdx` with full setup instructions, following the standard C1 connector doc template.

**Changes:**
- Step 1: Set up a new Confluence connector in C1 (Baton search)
- Step 2: Kubernetes manifests (secrets + deployment), with env vars sourced from the README (`BATON_DOMAIN_URL`, `BATON_USERNAME`, `BATON_API_KEY`, `BATON_PROVISIONING`, `BATON_SKIP_PERSONAL_SPACES`)
- Step 3: Deploy

This mirrors the change in [ConductorOne/docs#206](https://github.com/ConductorOne/docs/pull/206).