### PR TITLE
Sync default verbs in config with connector hardcoded list

### DIFF
--- a/config_schema.json
+++ b/config_schema.json
@@ -152,11 +152,13 @@
       "stringSliceField": {
         "defaultValue": [
           "administer",
+          "archive",
           "create",
           "delete",
           "export",
           "read",
-          "restrict_content"
+          "restrict_content",
+          "update"
         ],
         "rules": {}
       }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,11 +11,13 @@ var defaultNouns = []string{
 
 var defaultVerbs = []string{
 	"administer",
+	"archive",
 	"create",
 	"delete",
 	"export",
 	"read",
 	"restrict_content",
+	"update",
 }
 
 var (


### PR DESCRIPTION
## Summary
- `pkg/config/config.go` `defaultVerbs` was missing `archive` and `update`, which are both present in the connector's `defaultVerbs` in `pkg/connector/connector.go` (used by `filterArgs` to validate/expand input). Adding them so the advertised config default matches the set the connector will actually accept.
- Regenerated `config_schema.json` to reflect the new default.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `make lint`
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)