### PR TITLE
Update connector page title to include parent company name

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,7 +1,7 @@
 ---
-title:"Set up an Atlassian Confluence connector"
+title: "Set up an Atlassian Confluence connector"
 description: "C1 provides identity governance for Confluence. Integrate your Confluence instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:title:"Set up an Atlassian Confluence connector"
+og:title: "Set up an Atlassian Confluence connector"
 og:description: "C1 provides identity governance for Confluence. Integrate your Confluence instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "Atlassian Confluence"
 ---

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Set up a Confluence connector"
+title:"Set up an Atlassian Confluence connector"
 description: "C1 provides identity governance for Confluence. Integrate your Confluence instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:title: "Set up a Confluence connector"
+og:title:"Set up an Atlassian Confluence connector"
 og:description: "C1 provides identity governance for Confluence. Integrate your Confluence instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "Atlassian Confluence"
 ---
@@ -53,7 +53,7 @@ A user with **Administrator** access in Confluence must perform this task.
     </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Confluence connector
 
@@ -112,7 +112,7 @@ A user with **Administrator** access in Confluence must perform this task.
     </Step>
 </Steps>
 
-**That's it!** Your Confluence connector is now pulling access data into C1.
+**Done.** Your Confluence connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 Follow these instructions to use the [Confluence](https://github.com/conductorone/baton-confluence) connector, hosted and run in your own environment.
@@ -235,7 +235,7 @@ spec:
     </Step>
 </Steps>
 
-**That's it!** Your Confluence connector is now pulling access data into C1.
+**Done.** Your Confluence connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
This PR updates the connector page title and og:title to include the parent company name for better discoverability and consistency across connector docs.

Also replaces any remaining instances of `That's it!` with `Done.`